### PR TITLE
fix(menu): correct overlay and enable keyboard navigation - FRONT-963

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ pipeline:
   # Deploy a preview
   deploy-preview:
     image: node:erbium
-    secrets: [netlify_auth_token, netlify_site_id, gh_token]
+    secrets: [gh_token, netlify_auth_token, netlify_site_id] 
     commands:
       - yarn clean
       - yarn build
@@ -49,11 +49,11 @@ pipeline:
   # Deploy latest develop to digitec.netlify.com
   deploy-staging:
     image: node:erbium
-    secrets: [netlify_auth_token, netlify_site_id]
+    secrets: [gh_token, netlify_auth_token, netlify_site_id]
     commands:
       - yarn clean
       - yarn build
-      - 'yarn netlify deploy --prod --site $${NETLIFY_SITE_ID} --message "Drone build: ${DRONE_BUILD_NUMBER}"'
+      - 'yarn netlify deploy --site $${NETLIFY_SITE_ID} --message "Drone build: ${DRONE_BUILD_NUMBER}" --prod'
     when:
       branch: develop
       event: push      

--- a/.drone.yml
+++ b/.drone.yml
@@ -38,7 +38,7 @@ pipeline:
     commands:
       - yarn clean
       - yarn build
-      - 'yarn netlify deploy --site $${NETLIFY_SITE_ID} --message "Drone build: ${DRONE_BUILD_NUMBER}"'
+      - yarn netlify deploy --site b68ede30-c5c4-4572-a606-f37d0e6b7ebb --message "Drone build: ${DRONE_BUILD_NUMBER}"
       - node scripts/set-pr-status.js
     when:
       event: [push, pull_request]      
@@ -53,7 +53,7 @@ pipeline:
     commands:
       - yarn clean
       - yarn build
-      - 'yarn netlify deploy --site $${NETLIFY_SITE_ID} --message "Drone build: ${DRONE_BUILD_NUMBER}" --prod'
+      - yarn netlify deploy --prod --site b68ede30-c5c4-4572-a606-f37d0e6b7ebb --message "Drone build: ${DRONE_BUILD_NUMBER}"
     when:
       branch: develop
       event: push      

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,3 @@
 .cache
 node_modules
 public
-
-# To be removed in FRONT-963
-src/components/Navbar/Navbar.jsx

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -1,9 +1,4 @@
-/**
- *
- * Navbar
- *
- */
-
+/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */
 import React from 'react';
 import { Link } from 'gatsby';
 import PropTypes from 'prop-types';
@@ -86,8 +81,8 @@ class Navbar extends React.PureComponent {
 
   handleRequestToggleDrawer(event) {
     const { drawerOpen } = this.state;
-
     event.preventDefault();
+
     this.setState({ drawerOpen: !drawerOpen });
   }
 
@@ -111,35 +106,38 @@ class Navbar extends React.PureComponent {
         }}
       >
         <input
+          tabIndex="0"
           type="checkbox"
           id="toggleDrawer"
           className={styles.toggleDrawer}
           checked={drawerOpen}
           aria-label="Toggle the drawer"
+          onClick={this.handleRequestToggleDrawer}
+          onKeyPress={this.handleRequestToggleDrawer}
         />
         <div className={styles.mobileBar}>
-          <label
-            htmlFor="toggleDrawer"
-            className={styles.navToggle}
-            onClick={this.handleRequestToggleDrawer}
-            id="toggle-drawer"
-            role="button"
+          <button
             aria-label="Toggle the drawer"
+            className={styles.navToggle}
+            id="toggle-drawer"
+            onClick={this.handleRequestToggleDrawer}
+            onKeyPress={this.handleRequestToggleDrawer}
+            tabIndex="0"
+            type="button"
           >
             <span />
             <span />
             <span />
-          </label>
+          </button>
           <div className={styles.titleContainer}>
             <h1 className={styles.title}>{title}</h1>
           </div>
         </div>
         <label
-          htmlFor="toggleDrawer"
-          className={styles.overlay}
-          onClick={this.handleRequestToggleDrawer}
-          role="button"
           aria-label="Toggle the drawer"
+          className={styles.overlay}
+          htmlFor="toggleDrawer"
+          onClick={this.closeDrawer}
         />
         <div
           className={styles.navigation}

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -50,6 +50,8 @@
 }
 
 .navToggle {
+  background: none;
+  border: none;
   display: block;
   height: $header-height;
   position: relative;
@@ -233,8 +235,8 @@
 }
 
 .logoEuropa {
-  height: 43px;
-  width: 60px;
+  height: 37px;
+  width: 55px;
 }
 
 .logo {

--- a/src/html.js
+++ b/src/html.js
@@ -1,63 +1,62 @@
-/* eslint-disable global-require,react/prefer-stateless-function, react/jsx-filename-extension, jsx-a11y/html-has-lang,react/prop-types,no-useless-escape */
+/* eslint-disable global-require, react/jsx-filename-extension, react/prop-types */
 const React = require('react');
 
-module.exports = class HTML extends React.Component {
-  render() {
-    let css;
-    const {
-      htmlAttributes,
-      headComponents,
-      bodyAttributes,
-      preBodyComponents,
-      postBodyComponents,
-      body,
-    } = this.props;
+const html = ({
+  htmlAttributes,
+  headComponents,
+  bodyAttributes,
+  preBodyComponents,
+  postBodyComponents,
+  body,
+}) => {
+  let css;
 
-    return (
-      <html {...htmlAttributes}>
-        <head>
-          <meta charSet="utf-8" />
-          <meta httpEquiv="x-ua-compatible" content="ie=edge" />
-          <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1, shrink-to-fit=no"
-          />
-          {headComponents}
-          {css}
-          <script
-            src="https://ec.europa.eu/wel/cookie-consent/consent.js"
-            type="text/javascript"
-            defer
-          />
-        </head>
-        <body {...bodyAttributes}>
-          {preBodyComponents}
-          <div
-            key="body"
-            id="___gatsby"
-            dangerouslySetInnerHTML={{ __html: body }}
-          />
-          {postBodyComponents}
-          <script
-            defer
-            src="//europa.eu/webtools/load.js"
-            type="text/javascript"
-          />
-          <script
-            type="application/json"
-            dangerouslySetInnerHTML={{
-              __html: `
+  return (
+    <html lang="en" {...htmlAttributes}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        {headComponents}
+        {css}
+        <script
+          src="https://ec.europa.eu/wel/cookie-consent/consent.js"
+          type="text/javascript"
+          defer
+        />
+      </head>
+      <body {...bodyAttributes}>
+        {preBodyComponents}
+        <div
+          key="body"
+          id="___gatsby"
+          dangerouslySetInnerHTML={{ __html: body }}
+        />
+        {postBodyComponents}
+        <script
+          defer
+          src="//europa.eu/webtools/load.js"
+          type="text/javascript"
+        />
+        <script
+          type="application/json"
+          dangerouslySetInnerHTML={{
+            __html: `
               {
                   "utility": "piwik",
                   "siteID": 101,
-                  "sitePath": ["europa.eu\/digitec/2018"],
+                  "sitePath": ["europa.eu/digitec/2018"],
                   "instance": "europa.eu"
               }
             `,
-            }}
-          />
-        </body>
-      </html>
-    );
-  }
+          }}
+        />
+      </body>
+    </html>
+  );
 };
+
+module.exports = html;


### PR DESCRIPTION
Preview: https://5e7e1870ae612987f3cc0cc8--digitec.netlify.com/

Steps to test (and reproduce the issue here https://europa.eu/digitec/2018/)

- Use desktop browser and turn it to a mobile viewport to see the menu as "hamburger".
- Press anywhere within the application to make it active.
- Tab until you reach the hamburger menu button
- Press Enter to open the navigation overlay (does not work on production)
- Press Esc to close the navigation overlay
- Re-start tabbing. This should still enable you to open the navigation and reach menu items
- Selecting a menu item should close the navigation overlay 

The first label which is the actual interactive element has been converted to `button` in order to solve [accessibility concerns](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#Accessibility_concerns). The second label which is an overlay I annotated, but couldn't think of a better element which can represent this. The element should have an on-click event to close the overlay. That's the reason for adding [the ignores](https://github.com/ec-europa/digitec/pull/467/files#diff-0a6e06b17f243e14fdee70c9d1d48559R1), not the actual interactive label which becomes a button.
